### PR TITLE
fix(subscription): add the prefix to compare the signature header

### DIFF
--- a/src/core/Subscription.ts
+++ b/src/core/Subscription.ts
@@ -92,6 +92,6 @@ export class Subscription {
 
     const expectedHash: string = createHmac('sha256', this.secret).update(JSON.stringify(payload)).digest('hex');
 
-    return expectedHash === signatureHeader;
+    return `sha256=${expectedHash}` === signatureHeader;
   }
 }

--- a/test/subscription.test.ts
+++ b/test/subscription.test.ts
@@ -148,7 +148,7 @@ describe('Tests related to the Subscription class', () => {
     const fakePayloadSent: {} = {
       banksUserId: 'id',
     };
-    const hash: string = createHmac('sha256', secret).update(JSON.stringify(fakePayloadSent)).digest('hex');
+    const hash: string = `sha256=${createHmac('sha256', secret).update(JSON.stringify(fakePayloadSent)).digest('hex')}`;
 
     beforeEach(() => {
       requestBuilder = new RequestBuilder(baseUrl, {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add the header prefix to be able to compare properly the signature

## Motivation and Context

Algoan signature header contains the `sha256=` prefix in the `X-Hub-Signature` header.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
