### PR TITLE
feat(service-account): add a method to get a legal doc by id

### DIFF
--- a/src/core/LegalDocument.ts
+++ b/src/core/LegalDocument.ts
@@ -62,6 +62,23 @@ export class LegalDocument extends Document implements ILegalDocument {
   }
 
   /**
+   * Get a legal document by id
+   * @param requestBuilder Request Builder
+   * @param params identifiers required to get the resource
+   */
+  public static async getById(
+    requestBuilder: RequestBuilder,
+    params: { folderId: string; legalDocumentId: string },
+  ): Promise<LegalDocument> {
+    const legalDocument: ILegalDocument = await requestBuilder.request({
+      method: 'GET',
+      url: `/v1/folders/${params.folderId}/legal-documents/${params.legalDocumentId}`,
+    });
+
+    return new LegalDocument(legalDocument, params.folderId, requestBuilder);
+  }
+
+  /**
    * Get one file in a specific document section, in a chosen folder.
    *
    * @param requestBuilder Service account request builder

--- a/src/core/ServiceAccount.ts
+++ b/src/core/ServiceAccount.ts
@@ -190,4 +190,12 @@ export class ServiceAccount {
   }): Promise<LegalFile> {
     return LegalDocument.getFileById(this.requestBuilder, params);
   }
+
+  /**
+   * Get a legal document by id
+   * @param params folder and document identifiers
+   */
+  public async getLegalDocumentById(params: { folderId: string; legalDocumentId: string }): Promise<LegalDocument> {
+    return LegalDocument.getById(this.requestBuilder, params);
+  }
 }

--- a/test/legal-document.test.ts
+++ b/test/legal-document.test.ts
@@ -74,6 +74,25 @@ describe('Tests related to the LegalDocument class', () => {
     });
   });
 
+  describe('static getById()', () => {
+    beforeEach(() => {
+      legalDocumentAPI = getFakeAlgoanServer({
+        baseUrl,
+        path: `/v1/folders/${folderSample.id}/legal-documents/${legalDocumentSample.id}`,
+        response: legalDocumentSample,
+        method: 'get',
+      });
+    });
+    it('should fetch the specified file', async () => {
+      await LegalDocument.getById(requestBuilder, {
+        folderId: folderSample.id,
+        legalDocumentId: legalDocumentSample.id,
+      });
+
+      expect(legalDocumentAPI.isDone()).toBeTruthy();
+    });
+  });
+
   describe('uploadFile()', () => {
     beforeEach(() => {
       legalDocumentAPI = getFakeAlgoanServer({

--- a/test/service-account.test.ts
+++ b/test/service-account.test.ts
@@ -415,4 +415,31 @@ describe('Tests related to the ServiceAccount class', () => {
       expect(folderAPI.isDone()).toBeTruthy();
     });
   });
+
+  describe('getLegalDocumentById()', () => {
+    let folderAPI: nock.Scope;
+    beforeEach(() => {
+      folderAPI = getFakeAlgoanServer({
+        baseUrl,
+        path: `/v1/folders/${folderSample.id}/legal-documents/${legalDocumentSample.id}`,
+        response: legalDocumentSample,
+        method: 'get',
+      });
+    });
+    it('should fetch the specified document', async () => {
+      const serviceAccount: ServiceAccount = new ServiceAccount(baseUrl, {
+        clientId: 'a',
+        clientSecret: 'b',
+        id: '1',
+        createdAt: new Date().toISOString(),
+      });
+
+      await serviceAccount.getLegalDocumentById({
+        folderId: folderSample.id,
+        legalDocumentId: legalDocumentSample.id,
+      });
+
+      expect(folderAPI.isDone()).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
## Description

Give the ability to retrieve a legal document by its identifier

## Motivation and Context

To be able to retrieve files, I've added a `getLegalDocumentById` in the `ServiceAccount` class

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
