### PR TITLE
feat(request-builder): add logging interceptors for the request builder

### DIFF
--- a/src/Algoan.ts
+++ b/src/Algoan.ts
@@ -1,5 +1,5 @@
 import { RequestBuilder } from './RequestBuilder';
-import { PostSubscriptionDTO, EventName } from './lib';
+import { PostSubscriptionDTO, EventName, Logger } from './lib';
 import { ServiceAccount } from './core/ServiceAccount';
 import { Subscription } from './core';
 /**
@@ -21,12 +21,19 @@ export class Algoan {
 
   constructor(parameters: AlgoanOptions) {
     this.baseUrl = parameters.baseUrl;
-    this.requestBuilder = new RequestBuilder(this.baseUrl, {
-      clientId: parameters.clientId,
-      clientSecret: parameters.clientSecret,
-      username: parameters.username,
-      password: parameters.password,
-    });
+    this.requestBuilder = new RequestBuilder(
+      this.baseUrl,
+      {
+        clientId: parameters.clientId,
+        clientSecret: parameters.clientSecret,
+        username: parameters.username,
+        password: parameters.password,
+      },
+      {
+        logger: parameters.logger,
+        debug: parameters.debug,
+      },
+    );
     this.serviceAccounts = [];
   }
 
@@ -110,4 +117,6 @@ interface AlgoanOptions {
   baseUrl: string;
   username?: string;
   password?: string;
+  debug?: boolean;
+  logger?: Logger;
 }

--- a/src/lib/Logger.interface.ts
+++ b/src/lib/Logger.interface.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/tslint/config */
+/**
+ * Represents a generic logger that could be a simple console, winston etc.
+ */
+export interface Logger {
+  debug(message?: any, ...optionalParams: any[]): void;
+  info(message?: any, ...optionalParams: any[]): void;
+  warn(message?: any, ...optionalParams: any[]): void;
+  error(message?: any, ...optionalParams: any[]): void;
+  [x: string]: any;
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,3 +3,4 @@ export * from './Algoan.enum';
 export * from './Algoan.dto';
 export * from './Application.interface';
 export * from './Folder.interface';
+export * from './Logger.interface';

--- a/test/request-builder.test.ts
+++ b/test/request-builder.test.ts
@@ -6,8 +6,16 @@ import { getOAuthServer, getFakeAlgoanServer } from './utils/fake-server.utils';
 
 describe('Tests related to the RequestBuilder class', () => {
   const baseUrl: string = 'http://localhost:3000';
+  let infoLogSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    infoLogSpy = jest.spyOn(console, 'info');
+    errorSpy = jest.spyOn(console, 'error');
+  });
 
   afterEach(() => {
+    jest.resetAllMocks();
     nock.cleanAll();
   });
 
@@ -152,11 +160,18 @@ describe('Tests related to the RequestBuilder class', () => {
     expect((requestBuilder as any).accessTokenInstance).toBeDefined();
   });
 
-  it('RB005 - should call the token API twice - expired refresh token', async () => {
-    const requestBuilder: RequestBuilder = new RequestBuilder(baseUrl, {
-      clientId: 'clientId',
-      clientSecret: 'clientSecret',
-    });
+  it('RB005 - should correctly log information', async () => {
+    const requestBuilder: RequestBuilder = new RequestBuilder(
+      baseUrl,
+      {
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+      },
+      {
+        debug: true,
+        logger: console,
+      },
+    );
     const oAuthServer: nock.Scope = getOAuthServer({
       baseUrl,
       isRefreshToken: false,
@@ -181,13 +196,138 @@ describe('Tests related to the RequestBuilder class', () => {
     expect(oAuthServer.isDone()).toBeFalsy();
     expect(randomAlgoanServer.isDone()).toBeFalsy();
     expect((requestBuilder as any).accessTokenInstance).toBeDefined();
+    expect((requestBuilder as any).axiosInstance.interceptors.request.handlers).toHaveLength(2);
+    expect((requestBuilder as any).axiosInstance.interceptors.response.handlers).toHaveLength(1);
+    expect(infoLogSpy).toHaveBeenCalledTimes(2);
+  });
 
-    await delay(200);
+  it('RB006 - should correctly log an error', async () => {
+    const requestBuilder: RequestBuilder = new RequestBuilder(
+      baseUrl,
+      {
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+      },
+      {
+        debug: true,
+        logger: console,
+      },
+    );
+    const oAuthServer: nock.Scope = getOAuthServer({
+      baseUrl,
+      isRefreshToken: false,
+      isUserPassword: false,
+      nbOfCalls: 2,
+      expiresIn: 0,
+      refreshExpiresIn: 0,
+    });
+    const randomAlgoanServer: nock.Scope = getFakeAlgoanServer({
+      baseUrl,
+      method: 'get',
+      path: '/',
+      response: [],
+      nbOfCalls: 2,
+      status: 404,
+    });
+
+    await expect(
+      requestBuilder.request({
+        method: 'GET',
+        url: '/',
+      }),
+    ).rejects.toThrowError();
+
+    expect(oAuthServer.isDone()).toBeFalsy();
+    expect(randomAlgoanServer.isDone()).toBeFalsy();
+    expect((requestBuilder as any).accessTokenInstance).toBeDefined();
+    expect((requestBuilder as any).axiosInstance.interceptors.request.handlers).toHaveLength(2);
+    expect((requestBuilder as any).axiosInstance.interceptors.response.handlers).toHaveLength(1);
+    expect(infoLogSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('RB007 - should have no log', async () => {
+    const requestBuilder: RequestBuilder = new RequestBuilder(
+      baseUrl,
+      {
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+      },
+      {
+        debug: true,
+      },
+    );
+    const oAuthServer: nock.Scope = getOAuthServer({
+      baseUrl,
+      isRefreshToken: false,
+      isUserPassword: false,
+      nbOfCalls: 2,
+      expiresIn: 0,
+      refreshExpiresIn: 0,
+    });
+    const randomAlgoanServer: nock.Scope = getFakeAlgoanServer({
+      baseUrl,
+      method: 'get',
+      path: '/',
+      response: [],
+      nbOfCalls: 2,
+    });
 
     await requestBuilder.request({
       method: 'GET',
       url: '/',
     });
-    expect(randomAlgoanServer.isDone()).toBeTruthy();
+
+    expect(oAuthServer.isDone()).toBeFalsy();
+    expect(randomAlgoanServer.isDone()).toBeFalsy();
+    expect((requestBuilder as any).accessTokenInstance).toBeDefined();
+    expect((requestBuilder as any).axiosInstance.interceptors.request.handlers).toHaveLength(1);
+    expect((requestBuilder as any).axiosInstance.interceptors.response.handlers).toHaveLength(0);
+    expect(infoLogSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('RB008 - should not display logs', async () => {
+    const requestBuilder: RequestBuilder = new RequestBuilder(
+      baseUrl,
+      {
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+      },
+      {
+        debug: false,
+        logger: console,
+      },
+    );
+    const oAuthServer: nock.Scope = getOAuthServer({
+      baseUrl,
+      isRefreshToken: false,
+      isUserPassword: false,
+      nbOfCalls: 2,
+      expiresIn: 0,
+      refreshExpiresIn: 0,
+    });
+    const randomAlgoanServer: nock.Scope = getFakeAlgoanServer({
+      baseUrl,
+      method: 'get',
+      path: '/',
+      response: [],
+      nbOfCalls: 2,
+      status: 404,
+    });
+
+    await expect(
+      requestBuilder.request({
+        method: 'GET',
+        url: '/',
+      }),
+    ).rejects.toThrowError();
+
+    expect(oAuthServer.isDone()).toBeFalsy();
+    expect(randomAlgoanServer.isDone()).toBeFalsy();
+    expect((requestBuilder as any).accessTokenInstance).toBeDefined();
+    expect((requestBuilder as any).axiosInstance.interceptors.request.handlers).toHaveLength(1);
+    expect((requestBuilder as any).axiosInstance.interceptors.response.handlers).toHaveLength(0);
+    expect(infoLogSpy).toHaveBeenCalledTimes(0);
+    expect(errorSpy).toHaveBeenCalledTimes(0);
   });
 });

--- a/test/utils/fake-server.utils.ts
+++ b/test/utils/fake-server.utils.ts
@@ -55,6 +55,7 @@ export const getFakeAlgoanServer = (params: {
   path: string;
   response: Record<string, any>;
   nbOfCalls?: number;
+  status?: number;
 }): nock.Scope =>
   nock(params.baseUrl, {
     reqheaders: {
@@ -63,4 +64,4 @@ export const getFakeAlgoanServer = (params: {
   })
     [params.method](params.path)
     .times(params.nbOfCalls ?? 1)
-    .reply(200, params.response);
+    .reply(params.status ?? 200, params.response);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add an optional logger in the `RequestBuilder` class

## Motivation and Context

To be able to fully understand what happens in the Algoan SDK, the user should be able to activate a debug mode. By adding two optional parameters (a logger instance and a debug flag), we are now able to log requests sent through the request builder.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
