### PR TITLE
[FIX]: Add the suitable header for file upload

### DIFF
--- a/src/core/Document.ts
+++ b/src/core/Document.ts
@@ -1,6 +1,4 @@
-import { ReadStream } from 'fs';
 // eslint-disable-next-line  @typescript-eslint/no-require-imports
-import FormData = require('form-data');
 import {
   IDocument,
   Holder,
@@ -111,16 +109,16 @@ export abstract class Document implements IDocument {
    * readstream.
    *
    * @param readStream the readstream to transform
-   */
-  protected async getFilePayload(readStream: ReadStream): Promise<FormData> {
+   
+  protected static async getFilePayload(readStream: ReadStream): Promise<FormData> {
     return new Promise((resolve) => {
       readStream.on('end', async () => {
         const formData = new FormData();
-        formData.append(this.id, (readStream as unknown) as Blob);
+        formData.append('file', readStream);
         resolve(formData);
       });
-
+   
       readStream.read();
     });
-  }
+  }*/
 }

--- a/src/lib/Algoan.dto.ts
+++ b/src/lib/Algoan.dto.ts
@@ -1,4 +1,3 @@
-import { ReadStream } from 'fs';
 import { EventName, UsageType, AccountType, BanksUserTransactionType, BanksUserStatus } from './Algoan.enum';
 import { SubscriptionStatus, PlugIn, Score, Analysis, LoanDetails } from './Algoan.interface';
 import { ApplicationStatus, ExternalError } from './Application.interface';
@@ -111,10 +110,11 @@ export interface PostLegalDocumentDTO {
  * POST /folders/:id/legal-documents/:id/files DTO interface
  */
 export interface PostLegalFileDTO {
-  file?: ReadStream;
+  file?: any; // eslint-disable-line
   rejectionCode?: number;
   state?: FileState;
   type?: LegalFileType;
+  name?: string;
 }
 
 /**

--- a/test/legal-document.test.ts
+++ b/test/legal-document.test.ts
@@ -7,6 +7,7 @@ import { LegalDocument } from '../src';
 import {
   fileToUploadWithMedia,
   fileToUploadWithoutMedia,
+  fileToUploadWithMediaWithoutOtherInfos,
   legalDocumentSample,
   legalFileSample,
   newLegalDocuments,
@@ -116,6 +117,15 @@ describe('Tests related to the LegalDocument class', () => {
       const legalDocument = new LegalDocument(legalDocumentSample, folderSample.id, requestBuilder);
       const nbOfFiles = legalDocument.files.length;
       await legalDocument.uploadFile(fileToUploadWithMedia);
+
+      expect(legalDocumentAPI.isDone()).toBeTruthy();
+      expect(legalDocument.files.length).toBe(nbOfFiles + 1);
+    });
+
+    it('should upload the given file some properties are missing', async () => {
+      const legalDocument = new LegalDocument(legalDocumentSample, folderSample.id, requestBuilder);
+      const nbOfFiles = legalDocument.files.length;
+      await legalDocument.uploadFile(fileToUploadWithMediaWithoutOtherInfos);
 
       expect(legalDocumentAPI.isDone()).toBeTruthy();
       expect(legalDocument.files.length).toBe(nbOfFiles + 1);

--- a/test/samples/legal-document.ts
+++ b/test/samples/legal-document.ts
@@ -153,6 +153,7 @@ export const fileToUploadWithoutMedia: PostLegalFileDTO = {
   rejectionCode: 23,
   state: FileState.IN_PROGRESS,
   type: LegalFileType.BANK_RECORDS,
+  name: 'file name',
 };
 
 export const fileToUploadWithMedia: PostLegalFileDTO = {
@@ -160,6 +161,12 @@ export const fileToUploadWithMedia: PostLegalFileDTO = {
   rejectionCode: 23,
   state: FileState.IN_PROGRESS,
   type: LegalFileType.BANK_RECORDS,
+  name: 'file name',
+};
+
+export const fileToUploadWithMediaWithoutOtherInfos: PostLegalFileDTO = {
+  file: createReadStream(__filename),
+  name: 'file name',
 };
 
 export const newLegalDocuments: PostLegalDocumentDTO[] = [


### PR DESCRIPTION
# [FIX]: Add the suitable header for file upload
## Description
Add the headers to avoid the error : "Multipart: Boundary not found".
Handle the case the file is not a ReadStream. 
Note: the sdk should handle both, it will be done in a second time
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
