### PR TITLE
[FIX]: filter subscriptions by eventName

### DIFF
--- a/src/Algoan.ts
+++ b/src/Algoan.ts
@@ -68,13 +68,18 @@ export class Algoan {
       return;
     }
 
+    const eventNames: EventName[] =
+      typeof subscriptionOrTarget === 'string'
+        ? events
+        : subscriptionOrTarget.map((sub: PostSubscriptionDTO) => sub.eventName);
+
     const subscriptionDTO: PostSubscriptionDTO[] =
       typeof subscriptionOrTarget === 'string'
-        ? this.fromEventToSubscriptionDTO(subscriptionOrTarget, events, secret)
+        ? this.fromEventToSubscriptionDTO(subscriptionOrTarget, eventNames, secret)
         : subscriptionOrTarget;
 
     for (const serviceAccount of this.serviceAccounts) {
-      await serviceAccount.getOrCreateSubscriptions(subscriptionDTO);
+      await serviceAccount.getOrCreateSubscriptions(subscriptionDTO, eventNames);
     }
   }
 

--- a/src/core/ServiceAccount.ts
+++ b/src/core/ServiceAccount.ts
@@ -6,6 +6,7 @@ import {
   LegalFile,
   MultiResourceCreationResponse,
   PostLegalDocumentDTO,
+  EventName,
 } from '../lib';
 import { Subscription } from './Subscription';
 import { BanksUser } from './BanksUser';
@@ -77,8 +78,8 @@ export class ServiceAccount {
   /**
    * Fetch all subscriptions
    */
-  public async getSubscriptions(): Promise<Subscription[]> {
-    const subscriptions: Subscription[] = await Subscription.get(this.requestBuilder);
+  public async getSubscriptions(events?: EventName[]): Promise<Subscription[]> {
+    const subscriptions: Subscription[] = await Subscription.get(this.requestBuilder, events);
     this.subscriptions = subscriptions;
 
     return subscriptions;
@@ -105,8 +106,11 @@ export class ServiceAccount {
    * Update them to the ACTIVE status if there are not active
    * @param subscriptionBodies Subscription request bodies to potentially create
    */
-  public async getOrCreateSubscriptions(subscriptionBodies: PostSubscriptionDTO[]): Promise<Subscription[]> {
-    const subscriptions: Subscription[] = await this.getSubscriptions();
+  public async getOrCreateSubscriptions(
+    subscriptionBodies: PostSubscriptionDTO[],
+    events?: EventName[],
+  ): Promise<Subscription[]> {
+    const subscriptions: Subscription[] = await this.getSubscriptions(events);
 
     if (subscriptions.length === 0) {
       return this.createSubscriptions(subscriptionBodies);

--- a/src/core/Subscription.ts
+++ b/src/core/Subscription.ts
@@ -41,10 +41,19 @@ export class Subscription {
    * Get all subscriptions attached to a service account
    * @param requestBuilder Service account request builder
    */
-  public static async get(requestBuilder: RequestBuilder): Promise<Subscription[]> {
+  public static async get(requestBuilder: RequestBuilder, events?: EventName[]): Promise<Subscription[]> {
+    let params = {};
+    if (Array.isArray(events) && events.length) {
+      params = {
+        filter: JSON.stringify({
+          eventName: { $in: events },
+        }),
+      };
+    }
     const subscriptions: ISubscription[] = await requestBuilder.request({
       url: '/v1/subscriptions',
       method: 'GET',
+      params,
     });
 
     return subscriptions.map((sub: ISubscription) => new Subscription(sub, requestBuilder));

--- a/test/algoan.test.ts
+++ b/test/algoan.test.ts
@@ -14,7 +14,11 @@ describe('Tests related to the Algoan class', () => {
     beforeEach(() => {
       subscriptionAPI = getFakeAlgoanServer({
         baseUrl,
-        path: '/v1/subscriptions',
+        path: `/v1/subscriptions?filter=${JSON.stringify({
+          eventName: {
+            $in: [EventName.APPLICATION_UPDATED, EventName.BANKREADER_COMPLETED],
+          },
+        })}`,
         response: subscriptionsSample,
         method: 'get',
         nbOfCalls: 2,
@@ -47,7 +51,7 @@ describe('Tests related to the Algoan class', () => {
         clientSecret: 'b',
       });
 
-      await client.initRestHooks('http', [EventName.APPLICATION_UPDATED], 'a');
+      await client.initRestHooks('http', [EventName.APPLICATION_UPDATED, EventName.BANKREADER_COMPLETED], 'a');
       expect(serviceAccountAPI.isDone()).toBeTruthy();
       expect(subscriptionAPI.isDone()).toBeTruthy();
 
@@ -69,7 +73,7 @@ describe('Tests related to the Algoan class', () => {
         clientSecret: 'b',
       });
 
-      await client.initRestHooks('http', [EventName.APPLICATION_UPDATED], 'a');
+      await client.initRestHooks('http', [EventName.APPLICATION_UPDATED, EventName.BANKREADER_COMPLETED], 'a');
       expect(serviceAccountAPI.isDone()).toBeTruthy();
       expect(subscriptionAPI.isDone()).toBeFalsy();
 
@@ -77,6 +81,13 @@ describe('Tests related to the Algoan class', () => {
     });
 
     it('ALG003 - should do nothing - no event', async () => {
+      subscriptionAPI = getFakeAlgoanServer({
+        baseUrl,
+        path: '/v1/subscriptions',
+        response: subscriptionsSample,
+        method: 'get',
+        nbOfCalls: 2,
+      });
       serviceAccountAPI = getFakeAlgoanServer({
         baseUrl,
         path: '/v1/service-accounts',
@@ -98,6 +109,14 @@ describe('Tests related to the Algoan class', () => {
     });
 
     it('ALG004 - should correctly get subscriptions and service accounts - multiple bodies', async () => {
+      subscriptionAPI = getFakeAlgoanServer({
+        baseUrl,
+        path: `/v1/subscriptions?filter=${JSON.stringify({ eventName: { $in: [EventName.APPLICATION_UPDATED] } })}`,
+        response: subscriptionsSample,
+        method: 'get',
+        nbOfCalls: 2,
+      });
+
       serviceAccountAPI = getFakeAlgoanServer({
         baseUrl,
         path: '/v1/service-accounts',

--- a/test/service-account.test.ts
+++ b/test/service-account.test.ts
@@ -83,7 +83,7 @@ describe('Tests related to the ServiceAccount class', () => {
         createdAt: new Date().toISOString(),
       });
 
-      await serviceAccount.getSubscriptions();
+      await serviceAccount.getSubscriptions([EventName.APPLICATION_UPDATED, EventName.BANKREADER_COMPLETED]);
       expect(serviceAccount.subscriptions).toHaveLength(2);
       expect(subscriptionSpy).toHaveBeenCalled();
     });
@@ -138,12 +138,15 @@ describe('Tests related to the ServiceAccount class', () => {
         createdAt: new Date().toISOString(),
       });
 
-      await serviceAccount.getOrCreateSubscriptions([
-        {
-          target: 'http://...',
-          eventName: EventName.APPLICATION_UPDATED,
-        },
-      ]);
+      await serviceAccount.getOrCreateSubscriptions(
+        [
+          {
+            target: 'http://...',
+            eventName: EventName.APPLICATION_UPDATED,
+          },
+        ],
+        [EventName.APPLICATION_UPDATED, EventName.BANKREADER_COMPLETED],
+      );
       expect(serviceAccount.subscriptions).toHaveLength(2);
       expect(getSubscriptionSpy).toHaveBeenCalled();
       expect(createSubscriptionSpy).not.toHaveBeenCalled();
@@ -159,12 +162,15 @@ describe('Tests related to the ServiceAccount class', () => {
         createdAt: new Date().toISOString(),
       });
 
-      await serviceAccount.getOrCreateSubscriptions([
-        {
-          target: 'http://...',
-          eventName: EventName.APPLICATION_UPDATED,
-        },
-      ]);
+      await serviceAccount.getOrCreateSubscriptions(
+        [
+          {
+            target: 'http://...',
+            eventName: EventName.APPLICATION_UPDATED,
+          },
+        ],
+        [EventName.APPLICATION_UPDATED, EventName.BANKREADER_COMPLETED],
+      );
       expect(serviceAccount.subscriptions).toHaveLength(1);
       expect(getSubscriptionSpy).toHaveBeenCalled();
       expect(createSubscriptionSpy).toHaveBeenCalled();
@@ -188,12 +194,15 @@ describe('Tests related to the ServiceAccount class', () => {
         createdAt: new Date().toISOString(),
       });
 
-      await serviceAccount.getOrCreateSubscriptions([
-        {
-          target: 'http://...',
-          eventName: EventName.APPLICATION_UPDATED,
-        },
-      ]);
+      await serviceAccount.getOrCreateSubscriptions(
+        [
+          {
+            target: 'http://...',
+            eventName: EventName.APPLICATION_UPDATED,
+          },
+        ],
+        [EventName.APPLICATION_UPDATED, EventName.BANKREADER_COMPLETED],
+      );
       expect(serviceAccount.subscriptions).toHaveLength(1);
       expect(getSubscriptionSpy).toHaveBeenCalled();
       expect(createSubscriptionSpy).not.toHaveBeenCalled();

--- a/test/subscription.test.ts
+++ b/test/subscription.test.ts
@@ -16,7 +16,11 @@ describe('Tests related to the Subscription class', () => {
     beforeEach(() => {
       subscriptionAPI = getFakeAlgoanServer({
         baseUrl,
-        path: '/v1/subscriptions',
+        path: `/v1/subscriptions?filter=${JSON.stringify({
+          eventName: {
+            $in: [EventName.APPLICATION_UPDATED, EventName.BANKREADER_COMPLETED],
+          },
+        })}`,
         response: subscriptionsSample,
         method: 'get',
       });
@@ -40,7 +44,25 @@ describe('Tests related to the Subscription class', () => {
     });
 
     it('SB001 - should get subscriptions', async () => {
-      const subscriptions: Subscription[] = await Subscription.get(requestBuilder);
+      const subscriptions: Subscription[] = await Subscription.get(requestBuilder, [
+        EventName.APPLICATION_UPDATED,
+        EventName.BANKREADER_COMPLETED,
+      ]);
+      expect(subscriptionAPI.isDone()).toBeTruthy();
+
+      for (const sb of subscriptions) {
+        expect(sb).toBeInstanceOf(Subscription);
+      }
+    });
+    it('SB002 - should get subscriptions (whithout event name filter)', async () => {
+      subscriptionAPI = getFakeAlgoanServer({
+        baseUrl,
+        path: `/v1/subscriptions`,
+        response: subscriptionsSample,
+        method: 'get',
+      });
+
+      const subscriptions: Subscription[] = await Subscription.get(requestBuilder, []);
       expect(subscriptionAPI.isDone()).toBeTruthy();
 
       for (const sb of subscriptions) {


### PR DESCRIPTION
# [FIX]: filter subscriptions by eventName
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Filter the subscriptions by their eventName when fetching them. This is to prevent from fetching wrong subscriptions that shares the same the chatflow and organization. 

## Note 
We should wait for the filter to be in production on the Algoan's API side before merging this

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
