### PR TITLE
[FEAT] Add subscription event request (GET and PATCH)

### DIFF
--- a/src/core/Subscription.ts
+++ b/src/core/Subscription.ts
@@ -2,6 +2,7 @@ import { createHmac } from 'crypto';
 
 import { EventName, SubscriptionStatus, ISubscription, PostSubscriptionDTO, PatchSubscriptionDTO } from '../lib';
 import { RequestBuilder } from '../RequestBuilder';
+import { SubscriptionEvent } from './SubscriptionEvent';
 
 /**
  * Subscription class
@@ -93,5 +94,13 @@ export class Subscription {
     const expectedHash: string = createHmac('sha256', this.secret).update(JSON.stringify(payload)).digest('hex');
 
     return `sha256=${expectedHash}` === signatureHeader;
+  }
+
+  /**
+   * Create an event
+   * @param id Unique event identifier
+   */
+  public event(id: string): SubscriptionEvent {
+    return new SubscriptionEvent({ eventId: id, subscriptionId: this.id }, this.requestBuilder);
   }
 }

--- a/src/core/SubscriptionEvent.ts
+++ b/src/core/SubscriptionEvent.ts
@@ -1,0 +1,49 @@
+import { GetSubscriptionEventsDTO, ISubscriptionEvent, PatchSubscriptionEventDTO } from '../lib';
+import { RequestBuilder } from '../RequestBuilder';
+
+/**
+ * SubscriptionEvent class
+ */
+export class SubscriptionEvent {
+  /**
+   * Unique event identifier
+   */
+  public eventId: string;
+  /**
+   * Unique subscription identifier
+   */
+  public subscriptionId: string;
+
+  constructor(params: { eventId: string; subscriptionId: string }, private readonly requestBuilder: RequestBuilder) {
+    this.eventId = params.eventId;
+    this.subscriptionId = params.subscriptionId;
+  }
+
+  /**
+   * Get the list of events emitted on a subscription for an applicationId
+   * @param params the parameters of the request
+   */
+  public static async get(
+    requestBuilder: RequestBuilder,
+    subscriptionId: string,
+    query: GetSubscriptionEventsDTO,
+  ): Promise<ISubscriptionEvent[]> {
+    return requestBuilder.request({
+      url: `/v1/subscriptions/${subscriptionId}/events`,
+      method: 'GET',
+      params: query,
+    });
+  }
+
+  /**
+   * Update a subscription's event status
+   * @param body Patch subscription's event request body
+   */
+  public async update(body: PatchSubscriptionEventDTO): Promise<ISubscriptionEvent & { id: string }> {
+    return this.requestBuilder.request({
+      url: `/v1/subscriptions/${this.subscriptionId}/events/${this.eventId}`,
+      method: 'PATCH',
+      data: body,
+    });
+  }
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,6 @@
 export * from './ServiceAccount';
 export * from './Subscription';
+export * from './SubscriptionEvent';
 export * from './BanksUser';
 export * from './Document';
 export * from './Folder';

--- a/src/lib/Algoan.dto.ts
+++ b/src/lib/Algoan.dto.ts
@@ -1,4 +1,11 @@
-import { EventName, UsageType, AccountType, BanksUserTransactionType, BanksUserStatus } from './Algoan.enum';
+import {
+  EventName,
+  UsageType,
+  AccountType,
+  BanksUserTransactionType,
+  BanksUserStatus,
+  EventStatus,
+} from './Algoan.enum';
 import { SubscriptionStatus } from './Algoan.interface';
 import { ApplicationStatus, ExternalError } from './Application.interface';
 import { PlugIn, Score, Analysis, LoanDetails } from './BanksUser.interface';
@@ -31,6 +38,25 @@ export interface PostSubscriptionDTO {
 export interface PatchSubscriptionDTO {
   /** Subscription status to update */
   status: SubscriptionStatus;
+}
+
+/**
+ * GET /subscriptions/:id/events DTO interface
+ */
+export interface GetSubscriptionEventsDTO {
+  /** The id of the application concerned by the event */
+  applicationId: string;
+  /** The index to which events are requested */
+  highIndex?: number;
+  /** The index from events are requested */
+  lowIndex?: number;
+}
+
+/**
+ * PATCH /subscriptions/:id/events/:eventId DTO interface
+ */
+export interface PatchSubscriptionEventDTO {
+  status: EventStatus;
 }
 
 /**

--- a/src/lib/Algoan.enum.ts
+++ b/src/lib/Algoan.enum.ts
@@ -69,6 +69,26 @@ export enum EventName {
   KYC_OTHERS_CONFIGURATION_REQUIRED = 'kyc_others_configuration_required',
 }
 
+/**
+ * Enum for EventStatus
+ */
+export enum EventStatus {
+  /** IN_PROGRESS: Algoan has just created the event and is about to call the resthook */
+  IN_PROGRESS = 'IN_PROGRESS',
+  /** ACK: The connector has acknowledged the request */
+  ACK = 'ACK',
+  /** PROCESSED: Warns Algoan that the process has been fully completed */
+  PROCESSED = 'PROCESSED',
+  /** FAILED: Warns Algoan that an error occurred during the process */
+  FAILED = 'FAILED',
+  /** ERROR: The API did not acknowledge the request */
+  ERROR = 'ERROR',
+  /** WARNING: A warning email has been sent to the organization's contact */
+  WARNING = 'WARNING',
+  /** CRITICAL: A critical email has been sent to the organization's contact */
+  CRITICAL = 'CRITICAL',
+}
+
 export type AnalysisAlerts =
   | 'LOW_ACCOUNTS_READABILITY'
   | 'ADEN_USER_DIVERGENCE'

--- a/src/lib/Algoan.interface.ts
+++ b/src/lib/Algoan.interface.ts
@@ -1,4 +1,4 @@
-import { EventName } from './Algoan.enum';
+import { EventName, EventStatus } from './Algoan.enum';
 
 /**
  * Service account body
@@ -22,6 +22,26 @@ export interface ISubscription {
   secret?: string;
   status: SubscriptionStatus;
   target: string;
+}
+
+/**
+ * Subscription's event interface
+ * https://developers.algoan.com/api/#operation/getResthookSubEvents
+ */
+export interface ISubscriptionEvent<IPayload extends { applicationId: string } = { applicationId: string }> {
+  /** Index of the event */
+  index: string;
+  /** Payload sent through the resthook */
+  payload: IPayload;
+  /** Status history of the event */
+  statuses: {
+    createdAt: Date;
+    name: EventStatus;
+  }[];
+  /** Subscription properties */
+  subscription: ISubscription;
+  /** When the resthook has been sent */
+  time: number;
 }
 
 /**

--- a/test/samples/subscriptions-events.ts
+++ b/test/samples/subscriptions-events.ts
@@ -1,0 +1,49 @@
+import { EventName, EventStatus } from '../../src/lib/Algoan.enum';
+import { ISubscriptionEvent } from '../../src/lib/Algoan.interface';
+
+export const subscriptionEvents: ISubscriptionEvent[] = [
+  {
+    index: '0',
+    payload: {
+      applicationId: 'applicationId',
+    },
+    statuses: [
+      {
+        createdAt: new Date(),
+        name: EventStatus.IN_PROGRESS,
+      },
+    ],
+    subscription: {
+      id: 'sub1',
+      target: 'http://mydns.com',
+      secret: 'a',
+      eventName: EventName.APPLICATION_UPDATED,
+      status: 'ACTIVE',
+    },
+    time: Date.now(),
+  },
+  {
+    index: '1',
+    payload: {
+      applicationId: 'applicationId',
+    },
+    statuses: [
+      {
+        createdAt: new Date(),
+        name: EventStatus.IN_PROGRESS,
+      },
+      {
+        createdAt: new Date(),
+        name: EventStatus.ACK,
+      },
+    ],
+    subscription: {
+      id: 'sub1',
+      target: 'http://mydns.com',
+      secret: 'a',
+      eventName: EventName.APPLICATION_UPDATED,
+      status: 'ACTIVE',
+    },
+    time: Date.now(),
+  },
+];

--- a/test/subscription-event.test.ts
+++ b/test/subscription-event.test.ts
@@ -1,0 +1,101 @@
+import * as nock from 'nock';
+
+import { RequestBuilder } from '../src/RequestBuilder';
+import { SubscriptionEvent } from '../src/core/SubscriptionEvent';
+import { EventStatus, ISubscriptionEvent } from '../src';
+import { getOAuthServer, getFakeAlgoanServer } from './utils/fake-server.utils';
+import { subscriptionEvents as subscriptionEventsSample } from './samples/subscriptions-events';
+
+describe('Tests related to the SubscriptionEvent class', () => {
+  describe('static get()', () => {
+    const baseUrl: string = 'http://localhost:3000';
+    let subscriptionEventAPI: nock.Scope;
+    let requestBuilder: RequestBuilder;
+    let subscriptionId: string = 'subscriptionId';
+    let applicationId: string = 'applicationId';
+
+    beforeEach(() => {
+      subscriptionEventAPI = getFakeAlgoanServer({
+        baseUrl,
+        path: `/v1/subscriptions/${subscriptionId}/events?applicationId=${applicationId}`,
+        response: subscriptionEventsSample,
+        method: 'get',
+      });
+      getOAuthServer({
+        baseUrl,
+        isRefreshToken: false,
+        isUserPassword: false,
+        nbOfCalls: 1,
+        expiresIn: 500,
+        refreshExpiresIn: 2000,
+      });
+      requestBuilder = new RequestBuilder(baseUrl, {
+        clientId: 'a',
+        clientSecret: 's',
+      });
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      nock.cleanAll();
+    });
+
+    it("SE001 - should get subscription's event", async () => {
+      const subscriptionsEvent: ISubscriptionEvent[] = await SubscriptionEvent.get(requestBuilder, subscriptionId, {
+        applicationId,
+      });
+      expect(subscriptionEventAPI.isDone()).toBeTruthy();
+      expect(subscriptionsEvent.length).toBeDefined();
+    });
+  });
+
+  describe('update()', () => {
+    const baseUrl: string = 'http://localhost:3000';
+    let subscriptionEventAPI: nock.Scope;
+    let requestBuilder: RequestBuilder;
+    let subscriptionId: string = 'subscriptionId';
+    let eventId: string = 'eventId';
+
+    beforeEach(() => {
+      subscriptionEventAPI = getFakeAlgoanServer({
+        baseUrl,
+        path: `/v1/subscriptions/${subscriptionId}/events/${eventId}`,
+        response: subscriptionEventsSample[0],
+        method: 'patch',
+      });
+      getOAuthServer({
+        baseUrl,
+        isRefreshToken: false,
+        isUserPassword: false,
+        nbOfCalls: 1,
+        expiresIn: 500,
+        refreshExpiresIn: 2000,
+      });
+      requestBuilder = new RequestBuilder(baseUrl, {
+        clientId: 'a',
+        clientSecret: 's',
+      });
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      nock.cleanAll();
+    });
+
+    it("SE020 - should update a subscription's event status", async () => {
+      const subscriptionEvent: SubscriptionEvent = new SubscriptionEvent(
+        {
+          eventId,
+          subscriptionId,
+        },
+        requestBuilder,
+      );
+
+      await subscriptionEvent.update({
+        status: EventStatus.ACK,
+      });
+
+      expect(subscriptionEventAPI.isDone()).toBeTruthy();
+    });
+  });
+});

--- a/test/subscription.test.ts
+++ b/test/subscription.test.ts
@@ -6,6 +6,7 @@ import { Subscription } from '../src/core/Subscription';
 import { EventName } from '../src';
 import { getOAuthServer, getFakeAlgoanServer } from './utils/fake-server.utils';
 import { subscriptions as subscriptionsSample } from './samples/subscriptions';
+import { SubscriptionEvent } from '../src/core/SubscriptionEvent';
 
 describe('Tests related to the Subscription class', () => {
   describe('static get()', () => {
@@ -203,6 +204,32 @@ describe('Tests related to the Subscription class', () => {
       );
 
       expect(subscription.validateSignature(hash, fakePayloadSent)).toBeFalsy();
+    });
+  });
+
+  describe('event()', () => {
+    let requestBuilder: RequestBuilder;
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      nock.cleanAll();
+    });
+    it('SB040 - should return a SubscriptionEvent', () => {
+      const subscription: Subscription = new Subscription(
+        {
+          target: 'baseUrl',
+          id: '1',
+          eventName: EventName.APPLICATION_UPDATED,
+          status: 'DISABLE',
+        },
+        requestBuilder,
+      );
+
+      const subscriptionEvent: SubscriptionEvent = subscription.event('eventId');
+
+      expect(subscriptionEvent).toBeInstanceOf(SubscriptionEvent);
+      expect(subscriptionEvent.eventId).toEqual('eventId');
+      expect(subscriptionEvent.subscriptionId).toEqual('1');
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add new request:

- [`GET /subscriptions/:subscriptionId/events?applicationId=applicationId`](https://developers.algoan.com/api/#operation/getResthookSubEvents)
- [`PATCH /subscriptions/:subscriptionId/events/:eventId`](https://developers.algoan.com/api/#operation/patchResthookSubEvents)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Required to PATCH the event's status in the budget-insight and bridge connectors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
